### PR TITLE
Add code and tests to support the Process endpoint

### DIFF
--- a/Resources/responses/process/already_authed.xml
+++ b/Resources/responses/process/already_authed.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Exception xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <Error xsi:type="BBSException">
+        <Message>Unable to auth</Message>
+        <Result>
+            <IssuerId>50</IssuerId>
+            <ResponseCode>98</ResponseCode>
+            <ResponseText>Transaction already processed</ResponseText>
+            <ResponseSource>Netaxept</ResponseSource>
+            <TransactionId>fdm-medlem-0000022</TransactionId>
+            <ExecutionTime>2018-06-08T12:01:02.7705311+02:00</ExecutionTime>
+            <MerchantId>200970</MerchantId>
+            <ExtraInfoOut>2030010</ExtraInfoOut>
+            <MaskedPan />
+            <MessageId>0aa8e5472ca64707b036121ba22525b7</MessageId>
+        </Result>
+    </Error>
+</Exception>

--- a/Resources/responses/process/auth.xml
+++ b/Resources/responses/process/auth.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ProcessResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <AuthorizationId>123810</AuthorizationId>
+    <BatchNumber>310</BatchNumber>
+    <ExecutionTime>2018-06-08T12:38:10.2775868+02:00</ExecutionTime>
+    <MerchantId>80085</MerchantId>
+    <Operation>AUTH</Operation>
+    <ResponseCode>OK</ResponseCode>
+    <TransactionId>fdm-medlem-0000023</TransactionId>
+</ProcessResponse>

--- a/Resources/responses/process/cancel.xml
+++ b/Resources/responses/process/cancel.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ProcessResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <BatchNumber>310</BatchNumber>
+    <ExecutionTime>2018-06-08T12:39:33.2464996+02:00</ExecutionTime>
+    <MerchantId>80085</MerchantId>
+    <Operation>ANNUL</Operation>
+    <ResponseCode>OK</ResponseCode>
+    <TransactionId>fdm-medlem-0000023</TransactionId>
+</ProcessResponse>

--- a/Resources/responses/process/cancel_non_authed.xml
+++ b/Resources/responses/process/cancel_non_authed.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Exception xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <Error xsi:type="GenericError">
+        <Message>Unable to annul, wrong state</Message>
+    </Error>
+</Exception>

--- a/Resources/responses/process/capture.xml
+++ b/Resources/responses/process/capture.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ProcessResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <BatchNumber>310</BatchNumber>
+    <ExecutionTime>2018-06-08T12:44:55.4684928+02:00</ExecutionTime>
+    <MerchantId>80085</MerchantId>
+    <Operation>CAPTURE</Operation>
+    <ResponseCode>OK</ResponseCode>
+    <TransactionId>fdm-medlem-0000024</TransactionId>
+</ProcessResponse>

--- a/Resources/responses/process/capture_without_auth.xml
+++ b/Resources/responses/process/capture_without_auth.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Exception xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <Error xsi:type="GenericError">
+        <Message>You cannot run capture on a transaction that never is authorized</Message>
+    </Error>
+</Exception>

--- a/Resources/responses/process/credit.xml
+++ b/Resources/responses/process/credit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ProcessResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <BatchNumber>310</BatchNumber>
+    <ExecutionTime>2018-06-08T12:45:49.7661681+02:00</ExecutionTime>
+    <MerchantId>80085</MerchantId>
+    <Operation>CREDIT</Operation>
+    <ResponseCode>OK</ResponseCode>
+    <TransactionId>fdm-medlem-0000024</TransactionId>
+</ProcessResponse>

--- a/Resources/responses/process/credit_without_capture.xml
+++ b/Resources/responses/process/credit_without_capture.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Exception xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <Error xsi:type="GenericError">
+        <Message>You cannot run credit on a transaction that has not been captured.</Message>
+    </Error>
+</Exception>

--- a/Resources/responses/process/invalid_transaction_id.xml
+++ b/Resources/responses/process/invalid_transaction_id.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Exception xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <Error xsi:type="GenericError">
+        <Message>Unable to find transaction</Message>
+    </Error>
+</Exception>

--- a/Resources/responses/process/missing_operation.xml
+++ b/Resources/responses/process/missing_operation.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Exception xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <Error xsi:type="ValidationException">
+        <Message>Missing operation</Message>
+    </Error>
+</Exception>

--- a/Resources/responses/process/no_credit_card_details.xml
+++ b/Resources/responses/process/no_credit_card_details.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Exception xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <Error xsi:type="ValidationException">
+        <Message>Issuer is undetermined</Message>
+    </Error>
+</Exception>

--- a/Resources/responses/process/no_parameters.xml
+++ b/Resources/responses/process/no_parameters.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Exception xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <Error xsi:type="AuthenticationException">
+        <Message>Test: Unable to authenticate merchant (credentials not passed)</Message>
+    </Error>
+</Exception>

--- a/Resources/responses/process/register_ok_but_auth_fails.xml
+++ b/Resources/responses/process/register_ok_but_auth_fails.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Exception xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <Error xsi:type="BBSException">
+        <Message>Unable to auth</Message>
+        <Result>
+            <IssuerId>3</IssuerId>
+            <ResponseCode>99</ResponseCode>
+            <ResponseText>Auth Reg Comp Failure)</ResponseText>
+            <ResponseSource>Netaxept</ResponseSource>
+            <TransactionId>fdm-medlem-0000026</TransactionId>
+            <ExecutionTime>2018-06-08T13:11:40.5696656+02:00</ExecutionTime>
+            <MerchantId>200970</MerchantId>
+            <ExtraInfoOut>2030010</ExtraInfoOut>
+            <MaskedPan />
+            <MessageId>09c8eceacd4f4b4fb2fe74be1513524c</MessageId>
+        </Result>
+    </Error>
+</Exception>

--- a/Resources/responses/process/sale.xml
+++ b/Resources/responses/process/sale.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ProcessResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <AuthorizationId>130833</AuthorizationId>
+    <BatchNumber>310</BatchNumber>
+    <ExecutionTime>2018-06-08T13:08:33.5645085+02:00</ExecutionTime>
+    <MerchantId>12000353</MerchantId>
+    <Operation>SALE</Operation>
+    <ResponseCode>OK</ResponseCode>
+    <TransactionId>fdm-medlem-0000025</TransactionId>
+</ProcessResponse>

--- a/Resources/responses/process/unknown_operation.xml
+++ b/Resources/responses/process/unknown_operation.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Exception xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <Error xsi:type="ValidationException">
+        <Message>Unknown operation: FRED</Message>
+    </Error>
+</Exception>

--- a/Resources/responses/process/verify.xml
+++ b/Resources/responses/process/verify.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ProcessResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <AuthorizationId>103851</AuthorizationId>
+    <ExecutionTime>2018-06-08T10:38:51.0037445+02:00</ExecutionTime>
+    <MerchantId>80085</MerchantId>
+    <Operation>VERIFY</Operation>
+    <ResponseCode>OK</ResponseCode>
+    <TransactionId>fdm-medlem-0000022</TransactionId>
+</ProcessResponse>

--- a/src/Netaxept/Api.php
+++ b/src/Netaxept/Api.php
@@ -17,6 +17,7 @@ use FDM\Netaxept\Exception\Exception;
 use FDM\Netaxept\Exception\Factory as ExceptionFactory;
 use FDM\Netaxept\Response\ErrorInterface;
 use FDM\Netaxept\Response\Factory as ResponseFactory;
+use FDM\Netaxept\Response\ProcessInterface;
 use FDM\Netaxept\Response\QueryInterface;
 use FDM\Netaxept\Response\RegisterInterface;
 use GuzzleHttp\Client;
@@ -114,6 +115,24 @@ class Api
         $response = $this->performRequest((string) $uri);
 
         Assert::isInstanceOf($response, RegisterInterface::class, 'Invalid response');
+
+        return $response;
+    }
+
+    /**
+     * Processes a transaction
+     *
+     * @param array $transactionData
+     *
+     * @return ProcessInterface
+     */
+    public function processTransaction(array $transactionData): ProcessInterface
+    {
+        $uri = $this->getUri('process', $this->getParameters($transactionData));
+        /** @var ProcessInterface $response */
+        $response = $this->performRequest((string) $uri);
+
+        Assert::isInstanceOf($response, ProcessInterface::class, 'Invalid response');
 
         return $response;
     }

--- a/src/Netaxept/Exception/BBSException.php
+++ b/src/Netaxept/Exception/BBSException.php
@@ -15,4 +15,22 @@ namespace FDM\Netaxept\Exception;
 
 class BBSException extends Exception
 {
+    private $result = [];
+
+    public function __construct(\SimpleXMLElement $xml)
+    {
+        foreach ($xml->Error->Result->children() as $tag) {
+            $this->result[lcfirst($tag->getName())] = (string) $tag;
+        }
+
+        parent::__construct($xml);
+    }
+
+    /**
+     * @return array
+     */
+    public function getResult(): array
+    {
+        return $this->result;
+    }
 }

--- a/src/Netaxept/Exception/Exception.php
+++ b/src/Netaxept/Exception/Exception.php
@@ -15,4 +15,9 @@ namespace FDM\Netaxept\Exception;
 
 class Exception extends \Exception
 {
+    public function __construct(\SimpleXMLElement $xml)
+    {
+        $message = (string) $xml->Error->Message;
+        parent::__construct($message);
+    }
 }

--- a/src/Netaxept/Exception/Factory.php
+++ b/src/Netaxept/Exception/Factory.php
@@ -54,6 +54,6 @@ class Factory
 
         $exceptionClass = $this->classMap[$exceptionType];
 
-        throw new $exceptionClass((string) $xml->Error->Message);
+        throw new $exceptionClass($xml);
     }
 }

--- a/src/Netaxept/Response/Process.php
+++ b/src/Netaxept/Response/Process.php
@@ -15,4 +15,13 @@ namespace FDM\Netaxept\Response;
 
 class Process extends AbstractResponse implements ProcessInterface
 {
+    public function getStatus(): string
+    {
+        return (string) $this->xml->ResponseCode;
+    }
+
+    public function getOperation(): string
+    {
+        return (string) $this->xml->Operation;
+    }
 }

--- a/src/Netaxept/Response/ProcessInterface.php
+++ b/src/Netaxept/Response/ProcessInterface.php
@@ -15,4 +15,7 @@ namespace FDM\Netaxept\Response;
 
 interface ProcessInterface
 {
+    public function getStatus(): string;
+
+    public function getOperation(): string;
 }

--- a/tests/TestCase/Netaxept/ApiProcessTest.php
+++ b/tests/TestCase/Netaxept/ApiProcessTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of the Netaxept API package.
+ *
+ * (c) Andrew Plank
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\TestCase\Netaxept;
+
+use FDM\Netaxept\Exception\BBSException;
+use PHPUnit\Framework\Assert;
+
+class ApiProcessTest extends ApiTest
+{
+    /**
+     * @expectedException \FDM\Netaxept\Exception\AuthenticationException
+     * @expectedExceptionMessage Test: Unable to authenticate merchant (credentials not passed)
+     */
+    public function testMissingParameters()
+    {
+        $this->getInstanceForRequestFixture('responses/process/no_parameters.xml')->processTransaction([]);
+    }
+
+    /**
+     * @expectedException \FDM\Netaxept\Exception\ValidationException
+     * @expectedExceptionMessage Missing operation
+     */
+    public function testMissingOperation()
+    {
+        $this->getInstanceForRequestFixture('responses/process/missing_operation.xml')->processTransaction([]);
+    }
+
+    /**
+     * @expectedException \FDM\Netaxept\Exception\ValidationException
+     * @expectedExceptionMessage Unknown operation: FRED
+     */
+    public function testUnknownOperation()
+    {
+        $this->getInstanceForRequestFixture('responses/process/unknown_operation.xml')->processTransaction([]);
+    }
+
+    /**
+     * @expectedException \FDM\Netaxept\Exception\GenericError
+     * @expectedExceptionMessage Unable to find transaction
+     */
+    public function testInvalidTransactionId()
+    {
+        $this->getInstanceForRequestFixture('responses/process/invalid_transaction_id.xml')->processTransaction([]);
+    }
+
+    /**
+     * If the user hasn't clicked through and proceeded to the payment window and entered his card details, then the
+     * transaction in Netaxept will not have any registered card details.... Which, when trying to auth, will result in
+     * a "Issuer is undetermined" error.
+     *
+     * @expectedException \FDM\Netaxept\Exception\ValidationException
+     * @expectedExceptionMessage Issuer is undetermined
+     */
+    public function testThatAuthingANonCompletedPaymentFails()
+    {
+        $this->getInstanceForRequestFixture('responses/process/no_credit_card_details.xml')->processTransaction([]);
+    }
+
+    /**
+     * @expectedException \FDM\Netaxept\Exception\GenericError
+     * @expectedExceptionMessage You cannot run capture on a transaction that never is authorized
+     */
+    public function testThatCapturingWithoutAuthFails()
+    {
+        $this->getInstanceForRequestFixture('responses/process/capture_without_auth.xml')->processTransaction([]);
+    }
+
+    /**
+     * @expectedException \FDM\Netaxept\Exception\GenericError
+     * @expectedExceptionMessage You cannot run credit on a transaction that has not been captured.
+     */
+    public function testThatCreditingWithoutCapturingFails()
+    {
+        $this->getInstanceForRequestFixture('responses/process/credit_without_capture.xml')->processTransaction([]);
+    }
+
+    /**
+     * @expectedException \FDM\Netaxept\Exception\GenericError
+     * @expectedExceptionMessage Unable to annul, wrong state
+     */
+    public function testThatAttemptingToCancelANonAuthedTransactionFails()
+    {
+        $this->getInstanceForRequestFixture('responses/process/cancel_non_authed.xml')->processTransaction([]);
+    }
+
+    public function testThatAuthingAlreadyAuthedFails()
+    {
+        try {
+            $this->getInstanceForRequestFixture('responses/process/already_authed.xml')->processTransaction([]);
+        } catch (BBSException $e) {
+            Assert::assertEquals('Unable to auth', $e->getMessage());
+            Assert::assertEquals([
+                'issuerId' => '50',
+                'responseCode' => '98',
+                'responseText' => 'Transaction already processed',
+                'responseSource' => 'Netaxept',
+                'transactionId' => 'fdm-medlem-0000022',
+                'executionTime' => '2018-06-08T12:01:02.7705311+02:00',
+                'merchantId' => '200970',
+                'extraInfoOut' => '2030010',
+                'maskedPan' => '',
+                'messageId' => '0aa8e5472ca64707b036121ba22525b7',
+            ], $e->getResult(), 'Unexpected result!');
+
+            return;
+        }
+
+        throw new \Exception('It shouldn\'t get here');
+    }
+
+    public function testThatRegisterWorksButAuthFailsOnATestCard()
+    {
+        try {
+            $this->getInstanceForRequestFixture('responses/process/register_ok_but_auth_fails.xml')->processTransaction([]);
+        } catch (BBSException $e) {
+            Assert::assertEquals('Unable to auth', $e->getMessage());
+            Assert::assertEquals([
+                'issuerId' => '3',
+                'responseCode' => '99',
+                'responseText' => 'Auth Reg Comp Failure)',
+                'responseSource' => 'Netaxept',
+                'transactionId' => 'fdm-medlem-0000026',
+                'executionTime' => '2018-06-08T13:11:40.5696656+02:00',
+                'merchantId' => '200970',
+                'extraInfoOut' => '2030010',
+                'maskedPan' => '',
+                'messageId' => '09c8eceacd4f4b4fb2fe74be1513524c',
+            ], $e->getResult(), 'Unexpected result!');
+
+            return;
+        }
+
+        throw new \Exception('It shouldn\'t get here');
+    }
+
+    public function testThatVerifyingSucceeds()
+    {
+        $response = $this->getInstanceForRequestFixture('responses/process/verify.xml')->processTransaction([]);
+        Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
+        Assert::assertEquals('VERIFY', $response->getOperation(), 'Unexpected operation!');
+    }
+
+    public function testThatAuthSucceeds()
+    {
+        $response = $this->getInstanceForRequestFixture('responses/process/auth.xml')->processTransaction([]);
+        Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
+        Assert::assertEquals('AUTH', $response->getOperation(), 'Unexpected operation!');
+    }
+
+    public function testThatCancelSucceeds()
+    {
+        $response = $this->getInstanceForRequestFixture('responses/process/cancel.xml')->processTransaction([]);
+        Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
+        Assert::assertEquals('ANNUL', $response->getOperation(), 'Unexpected operation!');
+    }
+
+    public function testThatCaptureSucceeds()
+    {
+        $response = $this->getInstanceForRequestFixture('responses/process/capture.xml')->processTransaction([]);
+        Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
+        Assert::assertEquals('CAPTURE', $response->getOperation(), 'Unexpected operation!');
+    }
+
+    public function testThatCreditSucceeds()
+    {
+        $response = $this->getInstanceForRequestFixture('responses/process/credit.xml')->processTransaction([]);
+        Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
+        Assert::assertEquals('CREDIT', $response->getOperation(), 'Unexpected operation!');
+    }
+
+    public function testThatSaleSucceeds()
+    {
+        $response = $this->getInstanceForRequestFixture('responses/process/sale.xml')->processTransaction([]);
+        Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
+        Assert::assertEquals('SALE', $response->getOperation(), 'Unexpected operation!');
+    }
+}


### PR DESCRIPTION
Add code and error handling for the Process endpoint in order to support
the following Netaxept operations: VERIFY, AUTH, CAPTURE, SALE, ANNUL, CREDIT.