### PR TITLE
Make necessary changes that became apparent...

### DIFF
--- a/Resources/responses/process/missing_operation.xml
+++ b/Resources/responses/process/missing_operation.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Exception xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <Error xsi:type="ValidationException">
-        <Message>Missing operation</Message>
-    </Error>
-</Exception>

--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -121,7 +121,6 @@ services:
     PhpCsFixer\Fixer\Whitespace\IndentationTypeFixer: {}
     PhpCsFixer\Fixer\Whitespace\LineEndingFixer: {}
     PhpCsFixer\Fixer\Whitespace\NoExtraConsecutiveBlankLinesFixer:
-        - break
         - case
         - continue
         - curly_brace_block

--- a/src/Netaxept/Api.php
+++ b/src/Netaxept/Api.php
@@ -46,6 +46,7 @@ class Api
         'register' => 'Netaxept/Register.aspx',
         'process' => 'Netaxept/Process.aspx',
         'query' => 'Netaxept/Query.aspx',
+        'terminal' => 'Terminal/Default.aspx'
     ];
 
     /**
@@ -147,6 +148,19 @@ class Api
         Assert::isInstanceOf($response, ProcessInterface::class, 'Invalid response');
 
         return $response;
+    }
+
+    /**
+     * Given the transaction ID, returns a URI that the user should be redirected to in order to enter their card
+     * details for that transaction.
+     *
+     * @param string $transactionId
+     * @return Uri
+     */
+    public function getTerminalUri(string $transactionId): Uri
+    {
+        $uri = $this->getUri('terminal', ['merchantId' => $this->merchantId, 'transactionId' => $transactionId]);
+        return $uri;
     }
 
     /**

--- a/src/Netaxept/Api.php
+++ b/src/Netaxept/Api.php
@@ -30,6 +30,18 @@ class Api
 
     const SANDBOX_URL = 'https://test.epayment.nets.eu/';
 
+    const OPERATION_AUTH = 'auth';
+
+    const OPERATION_VERIFY = 'verify';
+
+    const OPERATION_SALE = 'sale';
+
+    const OPERATION_CAPTURE = 'capture';
+
+    const OPERATION_REFUND = 'credit';
+
+    const OPERATION_CANCEL = 'annul';
+
     const ENDPOINTS = [
         'register' => 'Netaxept/Register.aspx',
         'process' => 'Netaxept/Process.aspx',
@@ -126,9 +138,9 @@ class Api
      *
      * @return ProcessInterface
      */
-    public function processTransaction(array $transactionData): ProcessInterface
+    public function processTransaction(array $transactionData, string $operation): ProcessInterface
     {
-        $uri = $this->getUri('process', $this->getParameters($transactionData));
+        $uri = $this->getUri('process', $this->getParameters($transactionData + ['operation' => $operation]));
         /** @var ProcessInterface $response */
         $response = $this->performRequest((string) $uri);
 

--- a/src/Netaxept/Api.php
+++ b/src/Netaxept/Api.php
@@ -207,9 +207,9 @@ class Api
      * @param string $endpoint
      * @param array $parameters
      *
-     * @return \Psr\Http\Message\UriInterface
+     * @return Uri
      */
-    protected function getUri(string $endpoint, array $parameters = [])
+    protected function getUri(string $endpoint, array $parameters = []): Uri
     {
         Assert::keyExists(self::ENDPOINTS, $endpoint, "Named endpoint {$endpoint} is unknown.");
 

--- a/src/Netaxept/Api.php
+++ b/src/Netaxept/Api.php
@@ -46,7 +46,7 @@ class Api
         'register' => 'Netaxept/Register.aspx',
         'process' => 'Netaxept/Process.aspx',
         'query' => 'Netaxept/Query.aspx',
-        'terminal' => 'Terminal/Default.aspx'
+        'terminal' => 'Terminal/Default.aspx',
     ];
 
     /**
@@ -155,11 +155,13 @@ class Api
      * details for that transaction.
      *
      * @param string $transactionId
+     *
      * @return Uri
      */
     public function getTerminalUri(string $transactionId): Uri
     {
         $uri = $this->getUri('terminal', ['merchantId' => $this->merchantId, 'transactionId' => $transactionId]);
+
         return $uri;
     }
 

--- a/src/Netaxept/Exception/Factory.php
+++ b/src/Netaxept/Exception/Factory.php
@@ -28,7 +28,9 @@ class Factory
         $queryExceptionClass = QueryException::class,
         $securityExceptionClass = SecurityException::class,
         $uniqueTransactionIdExceptionClass = UniqueTransactionIdException::class,
-        $validationExceptionClass = ValidationException::class
+        $validationExceptionClass = ValidationException::class,
+        $transactionNotFoundExceptionClass = TransactionNotFoundException::class,
+        $transactionNotAuthorizedExceptionClass = TransactionNotAuthorizedException::class
     ) {
         $this->classMap = [
             'AuthenticationException' => $authenticationExceptionClass,
@@ -40,12 +42,19 @@ class Factory
             'UniqueTransactionIdException' => $uniqueTransactionIdExceptionClass,
             'ValidationException' => $validationExceptionClass,
             'QueryException' => $queryExceptionClass,
+            'TransactionNotFoundException' => $transactionNotFoundExceptionClass,
+            'TransactionNotAuthorizedException' => $transactionNotAuthorizedExceptionClass,
         ];
     }
 
     public function getException(\SimpleXMLElement $xml): Exception
     {
         $exceptionType = (string) $xml->Error->attributes('xsi', true)->type;
+
+        switch ($xml->Error->Message) {
+            case 'Unable to find transaction' : $exceptionType = 'TransactionNotFoundException'; break;
+            case 'You cannot run capture on a transaction that never is authorized' : $exceptionType = 'TransactionNotAuthorizedException'; break;
+        }
 
         Assert::notEmpty(
             $this->classMap[$exceptionType],

--- a/src/Netaxept/Exception/Factory.php
+++ b/src/Netaxept/Exception/Factory.php
@@ -52,8 +52,15 @@ class Factory
         $exceptionType = (string) $xml->Error->attributes('xsi', true)->type;
 
         switch ($xml->Error->Message) {
-            case 'Unable to find transaction' : $exceptionType = 'TransactionNotFoundException'; break;
-            case 'You cannot run capture on a transaction that never is authorized' : $exceptionType = 'TransactionNotAuthorizedException'; break;
+            case 'Unable to find transaction':
+                $exceptionType = 'TransactionNotFoundException';
+
+            break;
+
+            case 'You cannot run capture on a transaction that never is authorized':
+                $exceptionType = 'TransactionNotAuthorizedException';
+
+            break;
         }
 
         Assert::notEmpty(

--- a/src/Netaxept/Exception/TransactionNotAuthorizedException.php
+++ b/src/Netaxept/Exception/TransactionNotAuthorizedException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Netaxept API package.
+ *
+ * (c) Andrew Plank
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FDM\Netaxept\Exception;
+
+class TransactionNotAuthorizedException extends Exception
+{
+}

--- a/src/Netaxept/Exception/TransactionNotFoundException.php
+++ b/src/Netaxept/Exception/TransactionNotFoundException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Netaxept API package.
+ *
+ * (c) Andrew Plank
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace FDM\Netaxept\Exception;
+
+class TransactionNotFoundException extends Exception
+{
+}

--- a/src/Netaxept/Response/QueryInterface.php
+++ b/src/Netaxept/Response/QueryInterface.php
@@ -15,6 +15,8 @@ namespace FDM\Netaxept\Response;
 
 interface QueryInterface
 {
+    const STATUS_UNREGISTERED = 'unregistered';
+
     const STATUS_PENDING = 'pending';
 
     const STATUS_AUTHORIZED = 'authorized';
@@ -24,6 +26,8 @@ interface QueryInterface
     const STATUS_CANCELLED = 'cancelled';
 
     const STATUS_CREDITED = 'credited';
+
+    const STATUS_FAILED = 'failed';
 
     /**
      * Should determine the transaction status based on the data available in the response, which should be one of the

--- a/tests/TestCase/Netaxept/ApiProcessTest.php
+++ b/tests/TestCase/Netaxept/ApiProcessTest.php
@@ -24,16 +24,8 @@ class ApiProcessTest extends ApiTest
      */
     public function testMissingParameters()
     {
-        $this->getInstanceForRequestFixture('responses/process/no_parameters.xml')->processTransaction([]);
-    }
-
-    /**
-     * @expectedException \FDM\Netaxept\Exception\ValidationException
-     * @expectedExceptionMessage Missing operation
-     */
-    public function testMissingOperation()
-    {
-        $this->getInstanceForRequestFixture('responses/process/missing_operation.xml')->processTransaction([]);
+        $this->getInstanceForRequestFixture('responses/process/no_parameters.xml')
+            ->processTransaction([], 'required but unused');
     }
 
     /**

--- a/tests/TestCase/Netaxept/ApiProcessTest.php
+++ b/tests/TestCase/Netaxept/ApiProcessTest.php
@@ -42,7 +42,8 @@ class ApiProcessTest extends ApiTest
      */
     public function testUnknownOperation()
     {
-        $this->getInstanceForRequestFixture('responses/process/unknown_operation.xml')->processTransaction([]);
+        $this->getInstanceForRequestFixture('responses/process/unknown_operation.xml')
+            ->processTransaction([], 'required but unused');
     }
 
     /**
@@ -51,7 +52,8 @@ class ApiProcessTest extends ApiTest
      */
     public function testInvalidTransactionId()
     {
-        $this->getInstanceForRequestFixture('responses/process/invalid_transaction_id.xml')->processTransaction([]);
+        $this->getInstanceForRequestFixture('responses/process/invalid_transaction_id.xml')
+            ->processTransaction([], 'required but unused');
     }
 
     /**
@@ -64,7 +66,8 @@ class ApiProcessTest extends ApiTest
      */
     public function testThatAuthingANonCompletedPaymentFails()
     {
-        $this->getInstanceForRequestFixture('responses/process/no_credit_card_details.xml')->processTransaction([]);
+        $this->getInstanceForRequestFixture('responses/process/no_credit_card_details.xml')
+            ->processTransaction([], 'required but unused');
     }
 
     /**
@@ -73,7 +76,8 @@ class ApiProcessTest extends ApiTest
      */
     public function testThatCapturingWithoutAuthFails()
     {
-        $this->getInstanceForRequestFixture('responses/process/capture_without_auth.xml')->processTransaction([]);
+        $this->getInstanceForRequestFixture('responses/process/capture_without_auth.xml')
+            ->processTransaction([], 'required but unused');
     }
 
     /**
@@ -82,7 +86,8 @@ class ApiProcessTest extends ApiTest
      */
     public function testThatCreditingWithoutCapturingFails()
     {
-        $this->getInstanceForRequestFixture('responses/process/credit_without_capture.xml')->processTransaction([]);
+        $this->getInstanceForRequestFixture('responses/process/credit_without_capture.xml')
+            ->processTransaction([], 'required but unused');
     }
 
     /**
@@ -91,13 +96,15 @@ class ApiProcessTest extends ApiTest
      */
     public function testThatAttemptingToCancelANonAuthedTransactionFails()
     {
-        $this->getInstanceForRequestFixture('responses/process/cancel_non_authed.xml')->processTransaction([]);
+        $this->getInstanceForRequestFixture('responses/process/cancel_non_authed.xml')
+            ->processTransaction([], 'required but unused');
     }
 
     public function testThatAuthingAlreadyAuthedFails()
     {
         try {
-            $this->getInstanceForRequestFixture('responses/process/already_authed.xml')->processTransaction([]);
+            $this->getInstanceForRequestFixture('responses/process/already_authed.xml')
+                ->processTransaction([], 'required but unused');
         } catch (BBSException $e) {
             Assert::assertEquals('Unable to auth', $e->getMessage());
             Assert::assertEquals([
@@ -122,7 +129,8 @@ class ApiProcessTest extends ApiTest
     public function testThatRegisterWorksButAuthFailsOnATestCard()
     {
         try {
-            $this->getInstanceForRequestFixture('responses/process/register_ok_but_auth_fails.xml')->processTransaction([]);
+            $this->getInstanceForRequestFixture('responses/process/register_ok_but_auth_fails.xml')
+                ->processTransaction([], 'required but unused');
         } catch (BBSException $e) {
             Assert::assertEquals('Unable to auth', $e->getMessage());
             Assert::assertEquals([
@@ -146,42 +154,48 @@ class ApiProcessTest extends ApiTest
 
     public function testThatVerifyingSucceeds()
     {
-        $response = $this->getInstanceForRequestFixture('responses/process/verify.xml')->processTransaction([]);
+        $response = $this->getInstanceForRequestFixture('responses/process/verify.xml')
+            ->processTransaction([], 'required but unused');
         Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
         Assert::assertEquals('VERIFY', $response->getOperation(), 'Unexpected operation!');
     }
 
     public function testThatAuthSucceeds()
     {
-        $response = $this->getInstanceForRequestFixture('responses/process/auth.xml')->processTransaction([]);
+        $response = $this->getInstanceForRequestFixture('responses/process/auth.xml')
+            ->processTransaction([], 'required but unused');
         Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
         Assert::assertEquals('AUTH', $response->getOperation(), 'Unexpected operation!');
     }
 
     public function testThatCancelSucceeds()
     {
-        $response = $this->getInstanceForRequestFixture('responses/process/cancel.xml')->processTransaction([]);
+        $response = $this->getInstanceForRequestFixture('responses/process/cancel.xml')
+            ->processTransaction([], 'required but unused');
         Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
         Assert::assertEquals('ANNUL', $response->getOperation(), 'Unexpected operation!');
     }
 
     public function testThatCaptureSucceeds()
     {
-        $response = $this->getInstanceForRequestFixture('responses/process/capture.xml')->processTransaction([]);
+        $response = $this->getInstanceForRequestFixture('responses/process/capture.xml')
+            ->processTransaction([], 'required but unused');
         Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
         Assert::assertEquals('CAPTURE', $response->getOperation(), 'Unexpected operation!');
     }
 
     public function testThatCreditSucceeds()
     {
-        $response = $this->getInstanceForRequestFixture('responses/process/credit.xml')->processTransaction([]);
+        $response = $this->getInstanceForRequestFixture('responses/process/credit.xml')
+            ->processTransaction([], 'required but unused');
         Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
         Assert::assertEquals('CREDIT', $response->getOperation(), 'Unexpected operation!');
     }
 
     public function testThatSaleSucceeds()
     {
-        $response = $this->getInstanceForRequestFixture('responses/process/sale.xml')->processTransaction([]);
+        $response = $this->getInstanceForRequestFixture('responses/process/sale.xml')
+            ->processTransaction([], 'required but unused');
         Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
         Assert::assertEquals('SALE', $response->getOperation(), 'Unexpected operation!');
     }

--- a/tests/TestCase/Netaxept/ApiProcessTest.php
+++ b/tests/TestCase/Netaxept/ApiProcessTest.php
@@ -46,7 +46,7 @@ class ApiProcessTest extends ApiTest
     }
 
     /**
-     * @expectedException \FDM\Netaxept\Exception\GenericError
+     * @expectedException \FDM\Netaxept\Exception\TransactionNotFoundException
      * @expectedExceptionMessage Unable to find transaction
      */
     public function testInvalidTransactionId()
@@ -68,7 +68,7 @@ class ApiProcessTest extends ApiTest
     }
 
     /**
-     * @expectedException \FDM\Netaxept\Exception\GenericError
+     * @expectedException \FDM\Netaxept\Exception\TransactionNotAuthorizedException
      * @expectedExceptionMessage You cannot run capture on a transaction that never is authorized
      */
     public function testThatCapturingWithoutAuthFails()

--- a/tests/TestCase/Netaxept/ApiTerminalTest.php
+++ b/tests/TestCase/Netaxept/ApiTerminalTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Netaxept API package.
+ *
+ * (c) Andrew Plank
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\TestCase\Netaxept;
+
+use FDM\Netaxept\Api;
+use PHPUnit\Framework\Assert;
+
+class ApiTerminalTest extends ApiTest
+{
+    /**
+     * Test that the terminal URI is correct when in the sandbox
+     */
+    public function testSandboxTerminalUri()
+    {
+        Assert::assertEquals(
+            'https://test.epayment.nets.eu/Terminal/Default.aspx?merchantId=placeholdermerchant&transactionId=123456',
+            (new Api('placeholdermerchant', 'placeholdertoken', null, null, null, true))->getTerminalUri('123456')
+        );
+    }
+
+    /**
+     * Test that the terminal URI is correct when in production
+     */
+    public function testProductionTerminalUri()
+    {
+        Assert::assertEquals(
+            'https://epayment.nets.eu/Terminal/Default.aspx?merchantId=placeholdermerchant&transactionId=123456',
+            (new Api('placeholdermerchant', 'placeholdertoken'))->getTerminalUri('123456')
+        );
+    }
+}


### PR DESCRIPTION
...now that the code is being consumed. Several changes:

* Rather than delegating the logic to the consumer code, throw custom exceptions that indicate that the transaction is either unregistered or unauthorized. This is easier to handle in consumer code, than having to implement conditions and string comparison.
* To make the processTransaction method more readable in consumer code, require that the operation be provided as a 2nd parameter, rather than embedded as the 'operation' key inside the data or the first parameter.
* Provide some constants that enumerate the valid process operations.
* Since changing the processTransaction method, it is now no longer possible that a completely empty dataset can be sent to Netaxept, so remove the test for it.
* Add method for retrieving Netaxept's Terminal endpoint URI for a given transaction ID.
* Add two new states: "unregistered" and "failed".
* Change the return type of the getUri method to assist with code completion.