### PR TITLE
Implement better detection of user-cancelled payments.

### DIFF
--- a/Resources/responses/query/card_declined.xml
+++ b/Resources/responses/query/card_declined.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PaymentInfo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <MerchantId>1212121212</MerchantId>
+    <QueryFinished>2018-06-20T14:34:50.9677815+02:00</QueryFinished>
+    <TransactionId>bd4ae2b322a94d2199fb950a432f08cd</TransactionId>
+    <AuthenticationInformation />
+    <AvtaleGiroInformation />
+    <CardInformation>
+        <ExpiryDate>2401</ExpiryDate>
+        <Issuer>Visa</Issuer>
+        <IssuerCountry>NO</IssuerCountry>
+        <MaskedPAN>492500******0087</MaskedPAN>
+        <PaymentMethod>Visa</PaymentMethod>
+        <IssuerId>3</IssuerId>
+    </CardInformation>
+    <CustomerInformation>
+        <Address1 />
+        <Address2 />
+        <CompanyName />
+        <CompanyRegistrationNumber />
+        <CustomerNumber />
+        <Country />
+        <Email />
+        <FirstName />
+        <IP>87.48.129.98</IP>
+        <LastName />
+        <PhoneNumber />
+        <Postcode />
+        <SocialSecurityNumber />
+        <Town />
+    </CustomerInformation>
+    <Error>
+        <DateTime>2018-06-18T13:31:41.293</DateTime>
+        <Operation>Auth</Operation>
+        <ResponseCode>99</ResponseCode>
+        <ResponseSource>Netaxept</ResponseSource>
+        <ResponseText>Auth Reg Comp Failure)</ResponseText>
+    </Error>
+    <ErrorLog>
+        <PaymentError>
+            <DateTime>2018-06-18T13:31:41.293</DateTime>
+            <Operation>Auth</Operation>
+            <ResponseCode>99</ResponseCode>
+            <ResponseSource>Netaxept</ResponseSource>
+            <ResponseText>Auth Reg Comp Failure)</ResponseText>
+        </PaymentError>
+    </ErrorLog>
+    <History>
+        <TransactionLogLine>
+            <DateTime>2018-06-18T13:31:18.64</DateTime>
+            <Description>Test payment</Description>
+            <Operation>Register</Operation>
+            <TransactionReconRef />
+        </TransactionLogLine>
+    </History>
+    <OrderInformation>
+        <Amount>29995</Amount>
+        <Currency>DKK</Currency>
+        <Fee>0</Fee>
+        <OrderDescription> </OrderDescription>
+        <OrderNumber>80096</OrderNumber>
+        <Timestamp>2018-06-18T13:31:18.64</Timestamp>
+        <Total>29995</Total>
+        <RoundingAmount>0</RoundingAmount>
+    </OrderInformation>
+    <SecurityInformation>
+        <CustomerIPCountry>DK</CustomerIPCountry>
+        <IPCountryMatchesIssuingCountry>false</IPCountryMatchesIssuingCountry>
+    </SecurityInformation>
+    <Summary>
+        <AmountCaptured>0</AmountCaptured>
+        <AmountCredited>0</AmountCredited>
+        <Annuled>false</Annuled>
+        <Annulled>false</Annulled>
+        <Authorized>false</Authorized>
+    </Summary>
+    <TerminalInformation>
+        <Browser>Chrome-Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36</Browser>
+        <CustomerEntered>2018-06-18T13:31:19.013</CustomerEntered>
+        <CustomerRedirected>2018-06-18T13:31:39.747</CustomerRedirected>
+    </TerminalInformation>
+</PaymentInfo>

--- a/src/Netaxept/Response/AbstractResponse.php
+++ b/src/Netaxept/Response/AbstractResponse.php
@@ -32,11 +32,10 @@ class AbstractResponse implements ErrorInterface
 
     public function getError(): array
     {
-        return [
-            'dateTime' => (string) $this->xml->Error->DateTime,
-            'code' => (string) $this->xml->Error->ResponseCode,
-            'source' => (string) $this->xml->Error->ResponseSource,
-            'text' => (string) $this->xml->Error->ResponseText,
-        ];
+        $result = [];
+        foreach ($this->xml->Error->children() as $tag) {
+            $result[lcfirst($tag->getName())] = (string) $tag;
+        }
+        return $result;
     }
 }

--- a/src/Netaxept/Response/AbstractResponse.php
+++ b/src/Netaxept/Response/AbstractResponse.php
@@ -36,6 +36,7 @@ class AbstractResponse implements ErrorInterface
         foreach ($this->xml->Error->children() as $tag) {
             $result[lcfirst($tag->getName())] = (string) $tag;
         }
+
         return $result;
     }
 }

--- a/src/Netaxept/Response/Query.php
+++ b/src/Netaxept/Response/Query.php
@@ -22,6 +22,21 @@ class Query extends AbstractResponse implements QueryInterface, ErrorInterface
      */
     public function getTransactionStatus(): string
     {
+        // If the user cancelled in the terminal window, then we need to detect that.
+        if ($this->hasError()) {
+            $error = $this->getError();
+            if (
+                !empty($error['operation']) && $error['operation'] === 'Terminal' &&
+                !empty($error['responseCode']) && $error['responseCode'] === '17' &&
+                !empty($error['responseSource']) && ($error['responseSource'] === 'Terminal' || $error['responseSource'] === '05') &&
+                !empty($error['responseText']) && $error['responseText'] === 'Cancelled by customer.'
+            ) {
+                return QueryInterface::STATUS_CANCELLED;
+            }
+
+            return QueryInterface::STATUS_FAILED;
+        }
+
         $summary = $this->getSummary();
 
         // If the cancelled flag is set, then it can no longer be considered to be authed, captured or credited.

--- a/tests/TestCase/Netaxept/ApiQueryTest.php
+++ b/tests/TestCase/Netaxept/ApiQueryTest.php
@@ -129,7 +129,7 @@ class ApiQueryTest extends ApiTest
         Assert::assertEquals(535800, $trans->getOrderTotal());
     }
 
-    public function testErrorPresentAndCorrect()
+    public function testUserCancelled()
     {
         /** @var Query $trans */
         $trans = $this->getInstanceForRequestFixture('responses/query/user_cancelled.xml')->getTransaction('placeholder');
@@ -138,9 +138,28 @@ class ApiQueryTest extends ApiTest
         Assert::assertTrue($trans->hasError(), 'Response should contain error!');
         Assert::assertEquals([
             'dateTime' => '2018-04-05T10:58:45.933',
-            'code' => '17',
-            'source' => 'Terminal',
-            'text' => 'Cancelled by customer.',
+            'operation' => 'Terminal',
+            'responseCode' => '17',
+            'responseSource' => 'Terminal',
+            'responseText' => 'Cancelled by customer.',
         ], $trans->getError(), 'Incorrect error response received.');
+        Assert::assertEquals(QueryInterface::STATUS_CANCELLED, $trans->getTransactionStatus());
+    }
+
+    public function testCardDeclined()
+    {
+        /** @var Query $trans */
+        $trans = $this->getInstanceForRequestFixture('responses/query/card_declined.xml')->getTransaction('placeholder');
+
+        Assert::assertInstanceOf(Query::class, $trans);
+        Assert::assertTrue($trans->hasError(), 'Response should contain error!');
+        Assert::assertEquals([
+            'dateTime' => '2018-06-18T13:31:41.293',
+            'operation' => 'Auth',
+            'responseCode' => '99',
+            'responseSource' => 'Netaxept',
+            'responseText' => 'Auth Reg Comp Failure)',
+        ], $trans->getError(), 'Incorrect error response received.');
+        Assert::assertEquals(QueryInterface::STATUS_FAILED, $trans->getTransactionStatus());
     }
 }


### PR DESCRIPTION
When fetching the status of a payment, provide the correct "cancelled" status for transactions where the user cancelled before making the payment.