### PR TITLE
Add convenience methods that provide better action context.

### DIFF
--- a/src/Netaxept/Api.php
+++ b/src/Netaxept/Api.php
@@ -157,6 +157,83 @@ class Api
     }
 
     /**
+     * Register a transaction.
+     *
+     * @param array $transactionData
+     * @return RegisterInterface
+     */
+    public function register(array $transactionData): RegisterInterface
+    {
+        return $this->registerTransaction($transactionData);
+    }
+
+    /**
+     * Verify a transaction.
+     *
+     * @param array $transactionData
+     * @return ProcessInterface
+     */
+    public function verify(array $transactionData): ProcessInterface
+    {
+        return $this->processTransaction($transactionData, self::OPERATION_VERIFY);
+    }
+
+    /**
+     * Authorize a transaction.
+     *
+     * @param array $transactionData
+     * @return ProcessInterface
+     */
+    public function authorize(array $transactionData): ProcessInterface
+    {
+        return $this->processTransaction($transactionData, self::OPERATION_AUTH);
+    }
+
+    /**
+     * Cancel a transaction.
+     *
+     * @param array $transactionData
+     * @return ProcessInterface
+     */
+    public function cancel(array $transactionData): ProcessInterface
+    {
+        return $this->processTransaction($transactionData, self::OPERATION_CANCEL);
+    }
+
+    /**
+     * Capture a transaction.
+     *
+     * @param array $transactionData
+     * @return ProcessInterface
+     */
+    public function capture(array $transactionData): ProcessInterface
+    {
+        return $this->processTransaction($transactionData, self::OPERATION_CAPTURE);
+    }
+
+    /**
+     * Authorize and capture a transaction.
+     *
+     * @param array $transactionData
+     * @return ProcessInterface
+     */
+    public function sale(array $transactionData): ProcessInterface
+    {
+        return $this->processTransaction($transactionData, self::OPERATION_SALE);
+    }
+
+    /**
+     * Refunds a transaction.
+     *
+     * @param array $transactionData
+     * @return ProcessInterface
+     */
+    public function refund(array $transactionData): ProcessInterface
+    {
+        return $this->processTransaction($transactionData, self::OPERATION_REFUND);
+    }
+
+    /**
      * Given the transaction ID, returns a URI that the user should be redirected to in order to enter their card
      * details for that transaction.
      *

--- a/tests/TestCase/Netaxept/ApiProcessTest.php
+++ b/tests/TestCase/Netaxept/ApiProcessTest.php
@@ -152,10 +152,26 @@ class ApiProcessTest extends ApiTest
         Assert::assertEquals('VERIFY', $response->getOperation(), 'Unexpected operation!');
     }
 
+    public function testThatVerifyingSucceedsWithConvenienceMethod()
+    {
+        $response = $this->getInstanceForRequestFixture('responses/process/verify.xml')
+            ->verify([]);
+        Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
+        Assert::assertEquals('VERIFY', $response->getOperation(), 'Unexpected operation!');
+    }
+
     public function testThatAuthSucceeds()
     {
         $response = $this->getInstanceForRequestFixture('responses/process/auth.xml')
             ->processTransaction([], 'required but unused');
+        Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
+        Assert::assertEquals('AUTH', $response->getOperation(), 'Unexpected operation!');
+    }
+
+    public function testThatAuthSucceedsWithConvenienceMethod()
+    {
+        $response = $this->getInstanceForRequestFixture('responses/process/auth.xml')
+            ->authorize([]);
         Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
         Assert::assertEquals('AUTH', $response->getOperation(), 'Unexpected operation!');
     }
@@ -168,6 +184,14 @@ class ApiProcessTest extends ApiTest
         Assert::assertEquals('ANNUL', $response->getOperation(), 'Unexpected operation!');
     }
 
+    public function testThatCancelSucceedsWithConvenienceMethod()
+    {
+        $response = $this->getInstanceForRequestFixture('responses/process/cancel.xml')
+            ->cancel([]);
+        Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
+        Assert::assertEquals('ANNUL', $response->getOperation(), 'Unexpected operation!');
+    }
+
     public function testThatCaptureSucceeds()
     {
         $response = $this->getInstanceForRequestFixture('responses/process/capture.xml')
@@ -176,10 +200,26 @@ class ApiProcessTest extends ApiTest
         Assert::assertEquals('CAPTURE', $response->getOperation(), 'Unexpected operation!');
     }
 
-    public function testThatCreditSucceeds()
+    public function testThatCaptureSucceedsWithConvenienceMethod()
+    {
+        $response = $this->getInstanceForRequestFixture('responses/process/capture.xml')
+            ->capture([]);
+        Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
+        Assert::assertEquals('CAPTURE', $response->getOperation(), 'Unexpected operation!');
+    }
+
+    public function testThatRefundSucceeds()
     {
         $response = $this->getInstanceForRequestFixture('responses/process/credit.xml')
             ->processTransaction([], 'required but unused');
+        Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
+        Assert::assertEquals('CREDIT', $response->getOperation(), 'Unexpected operation!');
+    }
+
+    public function testThatRefundSucceedsWithConvenienceMethod()
+    {
+        $response = $this->getInstanceForRequestFixture('responses/process/credit.xml')
+            ->refund([]);
         Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
         Assert::assertEquals('CREDIT', $response->getOperation(), 'Unexpected operation!');
     }
@@ -188,6 +228,14 @@ class ApiProcessTest extends ApiTest
     {
         $response = $this->getInstanceForRequestFixture('responses/process/sale.xml')
             ->processTransaction([], 'required but unused');
+        Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
+        Assert::assertEquals('SALE', $response->getOperation(), 'Unexpected operation!');
+    }
+
+    public function testThatSaleSucceedsWithConvenienceMethod()
+    {
+        $response = $this->getInstanceForRequestFixture('responses/process/sale.xml')
+            ->sale([]);
         Assert::assertEquals('OK', $response->getStatus(), 'Unexpected status!');
         Assert::assertEquals('SALE', $response->getOperation(), 'Unexpected operation!');
     }

--- a/tests/TestCase/Netaxept/ApiRegisterTest.php
+++ b/tests/TestCase/Netaxept/ApiRegisterTest.php
@@ -28,6 +28,15 @@ class ApiRegisterTest extends ApiTest
 
     /**
      * @expectedException \FDM\Netaxept\Exception\ValidationException
+     * @expectedExceptionMessage Missing parameter: 'Order Number'
+     */
+    public function testMissingOrderIdButWithConvenienceMethod()
+    {
+        $this->getInstanceForRequestFixture('responses/register/missing_order_number.xml')->register([]);
+    }
+
+    /**
+     * @expectedException \FDM\Netaxept\Exception\ValidationException
      * @expectedExceptionMessage Missing parameter: 'Amount'
      */
     public function testMissingAmount()


### PR DESCRIPTION
Rather than having to invoke the same method with different parameters to perform the various actions supported by the Netaxept API, provide convenience methods named after the action to be performed in order to provide an interface that is less ambiguous in client code.